### PR TITLE
Adding MIT license link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,6 @@ Covert json to bootstrap grid with color, width and content
 
 <img src='sample.jpg'>
 
+### License
 
+Distributed under the MIT [License](https://github.com/99xt-incubator/json2bootgrid/blob/master/LICENSE). 


### PR DESCRIPTION
Issue #11 
I have added MIT license link to README file 